### PR TITLE
add PoC Yoast integration

### DIFF
--- a/assets/global-styles.css
+++ b/assets/global-styles.css
@@ -1,0 +1,163 @@
+:root {
+	/* Main colors */
+	--altis-blue: #4667de;
+	--altis-dark-blue: #152a4e;
+	--altis-off-white: #f3f5f9;
+	--altis-white: #fff;
+	--altis-light-gray: #dfe2e7;
+	--altis-dark-gray: #5b6983;
+
+	/* Secondary colors */
+	--altis-bright-blue: #436cff;
+	--altis-green: #3fcf8e;
+	--altis-darker-blue: #0f1a3c;
+	--altis-aqua: #1bafdd;
+	--altis-flamingo: #ed7b9d;
+	--altis-sunny: #f8da6d;
+}
+
+/* Yoast SEO color variable overrides */
+.wp-admin {
+    --yoast-border-default: 1px solid rgba(0,0,0,0.2);
+    --yoast-color-default: #404040;
+    --yoast-color-default-darker: #303030;
+    --yoast-color-primary: var( --altis-blue );
+    --yoast-color-secondary: var( --altis-off-white );
+    --yoast-color-white: var( --altis-white );
+    --yoast-color-green: var( --altis-green );
+    --yoast-color-primary-darker: var( --altis-dark-blue );
+    --yoast-color-primary-lighter: var( --altis-bright-blue );
+    --yoast-color-secondary-darker: var( --altis-light-gray );
+    --yoast-color-button-upsell: #fec228;
+    --yoast-color-button-upsell-hover: #f2ae01;
+    --yoast-color-dark: #303030;
+    --yoast-color-sale: #fec228;
+    --yoast-color-sale-darker: #feb601;
+    --yoast-color-border: rgba(0,0,0,0.2);
+    --yoast-color-label: #303030;
+    --yoast-color-label-help: #707070;
+    --yoast-color-active: #6ea029;
+    --yoast-color-inactive: #dc3232;
+    --yoast-color-inactive-text: #707070;
+    --yoast-color-inactive-grey: #9e9e9e;
+    --yoast-color-inactive-grey-light: #f1f1f1;
+    --yoast-color-active-light: #b6cf94;
+    --yoast-transition-default: all 150ms ease-out;
+    --yoast-color-link: var( --altis-blue );
+    --yoast-color-border--default: rgba(0,0,0,0.2);
+    --yoast-color-focus: 0 0 0 2px var( --altis-dark-blue ),0 0 0 5px #b6ceff;
+}
+
+.components-modal__content .yoast-modal-content input[type="radio"]:checked {
+	background: transparent;
+}
+
+.components-modal__content .components-modal__icon-container {
+	display: none;
+}
+
+.yoast #sidebar-container,
+.yoast .yoast_premium_upsell,
+.yoast #wpseo-local-seo-upsell {
+	display: none !important;
+}
+.wpseo-meta-section,
+.wpseo-meta-section-react,
+.fRzIon {
+	max-width: 100%;
+}
+
+.yoast .switch-toggle.switch-yoast-seo a,
+.yoast .switch-light.switch-yoast-seo a,
+.yoast .switch-light.switch-yoast-seo input:checked ~ span a,
+.yoast-field-group__radiobutton input[type=\"radio\"]:checked::after,
+.yoast span.yTsQm {
+	background-color: var( --altis-dark-blue );
+}
+.yoast-field-group__radiobutton input[type=\"radio\"]:checked,
+.wpseo_content_wrapper #separator input.radio:checked + label {
+	border-color: var( --altis-dark-blue );
+}
+.wpseo-metabox-menu ul li a {
+	color: var( --altis-blue );
+}
+.wpseo-metabox-menu ul li a:hover,
+.wpseo-metabox-menu ul li a:active {
+	color: var( --altis-bright-blue );
+}
+
+/* SEO Setup Wizard */
+#wizard a,
+#wizard a:visited {
+	color: var( --altis-blue );
+	text-decoration: none;
+}
+
+#wizard a:hover,
+#wizard a:active {
+	color: var( --altis-dark-blue );
+	border-bottom: 3px solid #3fcf8e;
+}
+
+#wizard .yoast-wizard--header svg {
+	display: none;
+}
+
+#wizard .yoast-wizard--header--page-title {
+	color: var( --altis-dark-blue );
+}
+
+#wizard .yoast-wizard-container h1 {
+	color: var( --altis-blue );
+}
+
+#wizard .yoast-wizard--heading {
+	color: var( --altis-dark-blue );
+}
+
+#wizard .yoast-wizard-container h3.yoast-wizard--heading {
+	color: var( --altis-blue );
+}
+
+#wizard .yoast-wizard--button {
+	color: var( --altis-blue );
+}
+
+#wizard .yoast-wizard--button::after {
+	border-bottom: 3px solid #3fcf8e;
+}
+
+#wizard .yoast-wizard-content-container button {
+	background-color: var( --altis-blue ) !important;
+}
+
+#wizard .yoast-wizard-content-container .yoast-wizard-image-upload-container-buttons__choose div span {
+	color: var( --altis-white ) !important;
+}
+
+#wizard .yoast-wizard-container .yoast-wizard--suggestion a {
+	background-color: var( --altis-blue ) !important;
+}
+
+#wizard .yoast-wizard-container .yoast-wizard--suggestion a div span {
+	color: var( --altis-white ) !important;
+}
+
+#wizard .yoast-wizard-container .yoast-wizard--suggestion a div svg {
+	color: var( --altis-white ) !important;
+	fill: var( --altis-white ) !important;
+}
+
+#wizard .yoast-wizard-container a#plugin-training-image-link:hover,
+#wizard .yoast-wizard-container a#plugin-training-image-link:active {
+	border-bottom: none;
+}
+
+.yoast-wizard--suggestion,
+.yoast-wizard--navigation {
+	border-color: var( --altis-dark-blue );
+}
+
+#wizard .yoast-wizard-input-radio-separator input:checked + label {
+	border-color: var( --altis-blue );
+}

--- a/assets/global-styles.css
+++ b/assets/global-styles.css
@@ -44,7 +44,7 @@
 }
 .wpseo-meta-section,
 .wpseo-meta-section-react,
-.fRzIon {
+#yoast-snippet-preview-container {
 	max-width: 100%;
 }
 

--- a/assets/global-styles.css
+++ b/assets/global-styles.css
@@ -18,16 +18,16 @@
 
 /* Yoast SEO color variable overrides */
 .wp-admin {
-    --yoast-color-primary: var( --altis-blue );
-    --yoast-color-secondary: var( --altis-off-white );
-    --yoast-color-white: var( --altis-white );
-    --yoast-color-green: var( --altis-green );
-    --yoast-color-primary-darker: var( --altis-dark-blue );
-    --yoast-color-primary-lighter: var( --altis-bright-blue );
-    --yoast-color-secondary-darker: var( --altis-light-gray );
-    --yoast-color-link: var( --altis-blue );
-    --yoast-color-border--default: rgba(0,0,0,0.2);
-    --yoast-color-focus: 0 0 0 2px var( --altis-dark-blue ),0 0 0 5px #b6ceff;
+	--yoast-color-primary: var( --altis-blue );
+	--yoast-color-secondary: var( --altis-off-white );
+	--yoast-color-white: var( --altis-white );
+	--yoast-color-green: var( --altis-green );
+	--yoast-color-primary-darker: var( --altis-dark-blue );
+	--yoast-color-primary-lighter: var( --altis-bright-blue );
+	--yoast-color-secondary-darker: var( --altis-light-gray );
+	--yoast-color-link: var( --altis-blue );
+	--yoast-color-border--default: rgba(0,0,0,0.2);
+	--yoast-color-focus: 0 0 0 2px var( --altis-dark-blue ),0 0 0 5px #b6ceff;
 }
 
 .components-modal__content .yoast-modal-content input[type="radio"]:checked {

--- a/assets/global-styles.css
+++ b/assets/global-styles.css
@@ -18,9 +18,6 @@
 
 /* Yoast SEO color variable overrides */
 .wp-admin {
-    --yoast-border-default: 1px solid rgba(0,0,0,0.2);
-    --yoast-color-default: #404040;
-    --yoast-color-default-darker: #303030;
     --yoast-color-primary: var( --altis-blue );
     --yoast-color-secondary: var( --altis-off-white );
     --yoast-color-white: var( --altis-white );
@@ -28,21 +25,6 @@
     --yoast-color-primary-darker: var( --altis-dark-blue );
     --yoast-color-primary-lighter: var( --altis-bright-blue );
     --yoast-color-secondary-darker: var( --altis-light-gray );
-    --yoast-color-button-upsell: #fec228;
-    --yoast-color-button-upsell-hover: #f2ae01;
-    --yoast-color-dark: #303030;
-    --yoast-color-sale: #fec228;
-    --yoast-color-sale-darker: #feb601;
-    --yoast-color-border: rgba(0,0,0,0.2);
-    --yoast-color-label: #303030;
-    --yoast-color-label-help: #707070;
-    --yoast-color-active: #6ea029;
-    --yoast-color-inactive: #dc3232;
-    --yoast-color-inactive-text: #707070;
-    --yoast-color-inactive-grey: #9e9e9e;
-    --yoast-color-inactive-grey-light: #f1f1f1;
-    --yoast-color-active-light: #b6cf94;
-    --yoast-transition-default: all 150ms ease-out;
     --yoast-color-link: var( --altis-blue );
     --yoast-color-border--default: rgba(0,0,0,0.2);
     --yoast-color-focus: 0 0 0 2px var( --altis-dark-blue ),0 0 0 5px #b6ceff;

--- a/assets/global-styles.css
+++ b/assets/global-styles.css
@@ -26,7 +26,6 @@
 	--yoast-color-primary-lighter: var( --altis-bright-blue );
 	--yoast-color-secondary-darker: var( --altis-light-gray );
 	--yoast-color-link: var( --altis-blue );
-	--yoast-color-border--default: rgba(0,0,0,0.2);
 	--yoast-color-focus: 0 0 0 2px var( --altis-dark-blue ),0 0 0 5px #b6ceff;
 }
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "php": ">=7.1",
         "humanmade/wp-seo": "0.14.0",
         "humanmade/hm-redirects": "~0.5.1",
-        "humanmade/meta-tags": "^0.1.6"
+        "humanmade/meta-tags": "^0.1.6",
+        "yoast/wordpress-seo": "^16.2.0"
     },
     "autoload": {
         "files": [
@@ -26,7 +27,8 @@
             "install-overrides": [
                 "humanmade/wp-seo",
                 "humanmade/hm-redirects",
-                "humanmade/meta-tags"
+                "humanmade/meta-tags",
+                "yoast/wordpress-seo"
             ]
         }
     }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -95,7 +95,6 @@ function bootstrap( Module $module ) {
 		";
 	} );
 
-
 	// Read config/robots.txt file into robots.txt route handled by WP.
 	add_filter( 'robots_txt', __NAMESPACE__ . '\\robots_txt', 10 );
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -42,23 +42,32 @@ function bootstrap( Module $module ) {
 		add_action( 'muplugins_loaded', __NAMESPACE__ . '\\use_tachyon_img_in_metadata' );
 	}
 
+	// Yoast SEO overrides PoC.
 	add_action( 'admin_init', function() {
+		// Remove the Dashboard widget.
 		remove_meta_box( 'wpseo-dashboard-overview', 'dashboard', 'normal' );
 		wp_dequeue_script( 'dashboard-widget' );
 		wp_dequeue_style( 'wp-dashboard' );
-		$options = get_option( 'wpseo', 'enable_admin_bar_menu' );
+
+		$options = get_option( 'wpseo' );
+		// Disable the admin bar menu.
 		$options['enable_admin_bar_menu'] = false;
 		if ( in_array( Altis\get_environment_type(), [ 'local', 'dev' ], true ) ) {
+			// Don't display the HUGE SEO issue on local or dev environments.
 			$options['ignore_search_engines_discouraged_notice'] = true;
 		}
 		update_option( 'wpseo', $options );
 
+		// Remove Helpscout.
 		add_filter( 'wpseo_helpscout_show_beacon', '__return_false' );
 
+		// Remove the Premium submenu.
 		$menu = 'wpseo_dashboard';
 		$submenu = 'wpseo_licenses';
 		remove_submenu_page( $menu, $submenu );
 	}, 11 );
+
+	// CSS overrides.
 	add_action( 'admin_head', function () {
 		echo "
 		<style type='text/css'>

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -68,38 +68,14 @@ function bootstrap( Module $module ) {
 	}, 11 );
 
 	// CSS overrides.
-	add_action( 'admin_head', function () {
+	add_action( 'admin_head', function() {
+		// These don't always hide if loaded in an actual stylesheet, so printing them in the admin head. TODO: they should probably be moved into a wp_print_styles function instead.
 		echo "
 		<style type='text/css'>
-			.yoast #sidebar-container,
-			.yoast .yoast_premium_upsell,
-			.yoast #wpseo-local-seo-upsell,
-			[class*=\"AnalysisUpsell__Container\"] {
-				display: none;
-			}
-			.yoast .switch-toggle.switch-yoast-seo a,
-			.yoast .switch-light.switch-yoast-seo a,
-			.yoast .switch-light.switch-yoast-seo input:checked ~ span a,
-			.yoast-field-group__radiobutton input[type=\"radio\"]:checked::after,
-			.yoast span.yTsQm {
-				background-color: #152a4e;
-			}
-			.yoast-field-group__radiobutton input[type=\"radio\"]:checked,
-			.wpseo_content_wrapper #separator input.radio:checked + label {
-				border-color: #1a335e;
-			}
-			.wpseo-metabox-menu ul li a {
-				color: #4667de;
-			}
-			.wpseo-metabox-menu ul li a:hover,
-			.wpseo-metabox-menu ul li a:active {
-				color; #2142ba;
-			}
-			.wpseo-meta-section,
-			.wpseo-meta-section-react,
-			.fRzIon {
-				max-width: 100%;
-			}
+		[class*=\"AnalysisUpsell__Container\"],
+		[class*=\"SocialUpsell__PremiumInfoText\"] {
+			display: none;
+		}
 		</style>
 		";
 	}, 11 );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -42,6 +42,60 @@ function bootstrap( Module $module ) {
 		add_action( 'muplugins_loaded', __NAMESPACE__ . '\\use_tachyon_img_in_metadata' );
 	}
 
+	add_action( 'admin_init', function() {
+		remove_meta_box( 'wpseo-dashboard-overview', 'dashboard', 'normal' );
+		wp_dequeue_script( 'dashboard-widget' );
+		wp_dequeue_style( 'wp-dashboard' );
+		$options = get_option( 'wpseo', 'enable_admin_bar_menu' );
+		$options['enable_admin_bar_menu'] = false;
+		if ( in_array( Altis\get_environment_type(), [ 'local', 'dev' ], true ) ) {
+			$options['ignore_search_engines_discouraged_notice'] = true;
+		}
+		update_option( 'wpseo', $options );
+
+		add_filter( 'wpseo_helpscout_show_beacon', '__return_false' );
+
+		$menu = 'wpseo_dashboard';
+		$submenu = 'wpseo_licenses';
+		remove_submenu_page( $menu, $submenu );
+	}, 11 );
+	add_action( 'admin_head', function () {
+		echo "
+		<style type='text/css'>
+			.yoast #sidebar-container,
+			.yoast .yoast_premium_upsell,
+			.yoast #wpseo-local-seo-upsell,
+			[class*=\"AnalysisUpsell__Container\"] {
+				display: none;
+			}
+			.yoast .switch-toggle.switch-yoast-seo a,
+			.yoast .switch-light.switch-yoast-seo a,
+			.yoast .switch-light.switch-yoast-seo input:checked ~ span a,
+			.yoast-field-group__radiobutton input[type=\"radio\"]:checked::after,
+			.yoast span.yTsQm {
+				background-color: #152a4e;
+			}
+			.yoast-field-group__radiobutton input[type=\"radio\"]:checked,
+			.wpseo_content_wrapper #separator input.radio:checked + label {
+				border-color: #1a335e;
+			}
+			.wpseo-metabox-menu ul li a {
+				color: #4667de;
+			}
+			.wpseo-metabox-menu ul li a:hover,
+			.wpseo-metabox-menu ul li a:active {
+				color; #2142ba;
+			}
+			.wpseo-meta-section,
+			.wpseo-meta-section-react,
+			.fRzIon {
+				max-width: 100%;
+			}
+		</style>
+		";
+	} );
+
+
 	// Read config/robots.txt file into robots.txt route handled by WP.
 	add_filter( 'robots_txt', __NAMESPACE__ . '\\robots_txt', 10 );
 }
@@ -72,6 +126,7 @@ function load_redirects() {
  */
 function load_metadata() {
 	require_once Altis\ROOT_DIR . '/vendor/humanmade/wp-seo/wp-seo.php';
+	require_once Altis\ROOT_DIR . '/vendor/yoast/wordpress-seo/wp-seo.php';
 	require_once Altis\ROOT_DIR . '/vendor/humanmade/meta-tags/plugin.php';
 
 	$config = Altis\get_config()['modules']['seo']['metadata'] ?? [];

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -102,6 +102,11 @@ function bootstrap( Module $module ) {
 			}
 		</style>
 		";
+	}, 11 );
+
+	// Load custom Altis CSS rebrand.
+	add_action( 'admin_enqueue_scripts', function() {
+		wp_enqueue_style( 'altis-seo', plugin_dir_url( dirname( __FILE__ ) ) . 'assets/global-styles.css', [], time() );
 	} );
 
 	// Read config/robots.txt file into robots.txt route handled by WP.

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -83,6 +83,12 @@ function bootstrap( Module $module ) {
 	// Load custom Altis CSS rebrand.
 	add_action( 'admin_enqueue_scripts', function() {
 		wp_enqueue_style( 'altis-seo', plugin_dir_url( dirname( __FILE__ ) ) . 'assets/global-styles.css', [], time() );
+	}, 11 );
+
+	// The Yoast Wizard bails early, before our styles are loaded, but we can hook into their action to load in our styles.
+	add_action( 'wpseo_configuration_wizard_head', function() {
+		wp_register_style( 'altis-seo', plugin_dir_url( dirname( __FILE__ ) ) . 'assets/global-styles.css', [], time() );
+		wp_print_styles( 'altis-seo' );
 	} );
 
 	// Read config/robots.txt file into robots.txt route handled by WP.


### PR DESCRIPTION
This PR is a proof of concept to illustrate things that would need to be changed/updated for a native Yoast integration. Screenshots in #49 

There's only one thing that I think might need to be done or made tweakable on their end, everything else we can mostly handle on our side as this PR illustrates.

This does not include `altis-core` changes to the plugin path that would need to be made. All the tweaks are loaded into a single anonymous function which obviously isn't how it would be when we're ready to ship. Likewise the custom CSS overrides would not be added in an `admin_head` hook.

I have questions about the apparent random classnames (e.g. `.yTsQm` and `.fRzIon`) -- if these are randomly generated at build time by some script and likely to change, then we can't rely on those classes for our style overrides. Would need to follow up with Yoast on how those are created and if they ever change.

There's also a "Add related keyphrase" accordion option that displays upsells if not on premium. This is handled via JavaScript with no easy hook point to remove or classes to hide it. We would likely need to work with them to at least add some static classes so we could hide the panel.