### PR TITLE
Replace WP SEO with Yoast

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
     ],
     "require": {
         "php": ">=7.1",
-        "humanmade/wp-seo": "0.14.0",
         "humanmade/hm-redirects": "~0.5.1",
-        "humanmade/meta-tags": "^0.1.6"
+        "humanmade/meta-tags": "^0.1.6",
+        "yoast/wordpress-seo": "^16.2.0"
     },
     "autoload": {
         "files": [
@@ -24,9 +24,9 @@
     "extra": {
         "altis": {
             "install-overrides": [
-                "humanmade/wp-seo",
                 "humanmade/hm-redirects",
-                "humanmade/meta-tags"
+                "humanmade/meta-tags",
+                "yoast/wordpress-seo"
             ]
         }
     }

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 ![](./assets/banner-seo.png)
 
-The SEO module provides a suite of tools for enhancing and managing your networks visibility to search engines and social platforms including Facebook and Twitter.
+The Altis SEO module is powered by [Yoast SEO](https://yoast.com/wordpress/plugins/seo/) for its advanced features. The SEO module provides a suite of tools for enhancing and managing your networks visibility to search engines and social platforms including Facebook and Twitter.
 
 ## Configuration
 
@@ -46,24 +46,8 @@ The following JSON is the default configuration for the module and can be overri
 }
 ```
 
-## Using Yoast SEO as an alternative
+## Using Yoast SEO Premium
 
-Depending on your needs you may wish to install [Yoast SEO](https://yoast.com/wordpress/plugins/seo/) for its advanced features. It is recommended to disable the Metadata and XML Sitemaps components if you do this using the following configuration.
-
-```json
-{
-	"extra": {
-		"altis": {
-			"modules": {
-				"seo": {
-					"enabled": true,
-					"metadata": false,
-					"xml-sitemaps": false,
-				}
-			}
-		}
-	}
-}
-```
+[Yoast SEO Premium](https://yoast.com/wordpress/plugins/seo/) adds more features and access to Yoast's support team. Altis SEO is configured in such a way that if you own a copy of Yoast SEO Premium, all you need to do is install it as a plugin or mu-plugin normally and it will work seamlessly without any additional configuration.
 
 **Note** if you are using a headless architecture many of the features of Yoast SEO will not function as expected.

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,4 +50,6 @@ The following JSON is the default configuration for the module and can be overri
 
 [Yoast SEO Premium](https://yoast.com/wordpress/plugins/seo/) adds more features and access to Yoast's support team. Altis SEO is configured in such a way that if you own a copy of Yoast SEO Premium, all you need to do is install it as a plugin or mu-plugin normally and it will work seamlessly without any additional configuration.
 
+We recommend installing Yoast SEO Premium using Composer. To do this follow the instructions linked to in the [Downloads section of MyYoast](https://my.yoast.com/downloads). You will be able to create a developer token and then be provided with the required `composer.json` updates and commands to run.
+
 **Note** if you are using a headless architecture many of the features of Yoast SEO will not function as expected.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 ![](./assets/banner-seo.png)
 
-The Altis SEO module is powered by [Yoast SEO](https://yoast.com/wordpress/plugins/seo/) for its advanced features. The SEO module provides a suite of tools for enhancing and managing your networks visibility to search engines and social platforms including Facebook and Twitter.
+The Altis SEO module is powered by [Yoast SEO](https://yoast.com/wordpress/plugins/seo/) for its advanced features. The SEO module provides a suite of tools for enhancing and managing your network's visibility to search engines and social platforms including Facebook and Twitter.
 
 ## Configuration
 

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -72,8 +72,14 @@ function load_redirects() {
  * Load Yoast SEO.
  */
 function load_wpseo() {
-	defined( 'WPSEO_PREMIUM_FILE' ) or define( 'WPSEO_PREMIUM_FILE', true );
-	require_once Altis\ROOT_DIR . '/vendor/yoast/wordpress-seo/wp-seo.php';
+	$wpseo_file = Altis\ROOT_DIR . '/vendor/yoast/wordpress-seo/wp-seo.php';
+
+	// Define a fake WP SEO Premium File value if we don't have WP SEO Premium installed. This hides some of the upsell UI.
+	if ( ! class_exists( 'WPSEO_Premium' ) ) {
+		define( 'WPSEO_PREMIUM_FILE', $wpseo_file );
+		define( 'WPSEO_PREMIUM_VERSION', 8 );
+		require_once $wpseo_file;
+	}
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -43,7 +43,7 @@ function bootstrap( Module $module ) {
 	}
 
 	// Load Yoast SEO late in case WP SEO Premium is installed as a plugin or mu-plugin.
-	add_action( 'plugins_loaded', __NAMESPACE__ . '\\load_wpseo', 100 );
+	add_action( 'plugins_loaded', __NAMESPACE__ . '\\load_wpseo', 1 );
 
 	// Read config/robots.txt file into robots.txt route handled by WP.
 	add_filter( 'robots_txt', __NAMESPACE__ . '\\robots_txt', 10 );

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -76,8 +76,10 @@ function load_wpseo() {
 
 	// Define a fake WP SEO Premium File value if we don't have WP SEO Premium installed. This hides some of the upsell UI.
 	if ( ! class_exists( 'WPSEO_Premium' ) ) {
-		define( 'WPSEO_PREMIUM_FILE', $wpseo_file );
-		define( 'WPSEO_PREMIUM_VERSION', 8 );
+		if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+			define( 'WPSEO_PREMIUM_FILE', $wpseo_file );
+			define( 'WPSEO_PREMIUM_VERSION', 8 );
+		}
 		require_once $wpseo_file;
 	}
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -78,7 +78,7 @@ function load_wpseo() {
 	if ( ! class_exists( 'WPSEO_Premium' ) ) {
 		if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 			define( 'WPSEO_PREMIUM_FILE', $wpseo_file );
-			define( 'WPSEO_PREMIUM_VERSION', 8 );
+			define( 'WPSEO_PREMIUM_VERSION', Altis\get_version() );
 		}
 		require_once $wpseo_file;
 	}

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -42,6 +42,9 @@ function bootstrap( Module $module ) {
 		add_action( 'muplugins_loaded', __NAMESPACE__ . '\\use_tachyon_img_in_metadata' );
 	}
 
+	// Load Yoast SEO late in case WP SEO Premium is installed as a plugin or mu-plugin.
+	add_action( 'plugins_loaded', __NAMESPACE__ . '\\load_wpseo', 100 );
+
 	// Read config/robots.txt file into robots.txt route handled by WP.
 	add_filter( 'robots_txt', __NAMESPACE__ . '\\robots_txt', 10 );
 }
@@ -66,12 +69,19 @@ function load_redirects() {
 }
 
 /**
+ * Load Yoast SEO.
+ */
+function load_wpseo() {
+	defined( 'WPSEO_PREMIUM_FILE' ) or define( 'WPSEO_PREMIUM_FILE', true );
+	require_once Altis\ROOT_DIR . '/vendor/yoast/wordpress-seo/wp-seo.php';
+}
+
+/**
  * Load the SEO metadata plugin.
  *
  * @return void
  */
 function load_metadata() {
-	require_once Altis\ROOT_DIR . '/vendor/humanmade/wp-seo/wp-seo.php';
 	require_once Altis\ROOT_DIR . '/vendor/humanmade/meta-tags/plugin.php';
 
 	$config = Altis\get_config()['modules']['seo']['metadata'] ?? [];


### PR DESCRIPTION
This PR removes the composer dependency for WP SEO and replaces it with Yoast. 
Also adds/updates documentation about SEO and using Yoast SEO Premium.

fixes #58 

**Notes:**
* It does not handle removing the XML sitemaps plugin or docs (#62)
* It does not handle removing/replacing metadata configuration settings (#57)
* It does not remove all of the upsells (#53) or the dashboard widget (#52) 