### PR TITLE
Remove XML sitemaps and replace with Yoast XML Sitemaps

### DIFF
--- a/docs/xml-sitemaps.md
+++ b/docs/xml-sitemaps.md
@@ -35,7 +35,7 @@ The above example works if `video` is the name of a post type that has not been 
 
 If a matching sitemap provider is not registered or cannot be found, the second parameter in the `register_sitemap` method must correspond to a callback function which must generate the entire sitemap XML.
 
-To remove a post type from your sitemaps, use the `wp_seo_sitemap_exclude_post_type` filter. The example below removes a post type registered as `recipe`.
+## Excluding Content From XML Sitemaps
 
 ```php
 add_filter( 'wpseo_sitemap_exclude_post_type', function ( $excluded, $post_type ) {

--- a/docs/xml-sitemaps.md
+++ b/docs/xml-sitemaps.md
@@ -31,6 +31,10 @@ add_action( 'init', function () {
 } );
 ```
 
+The above example works if `video` is the name of a post type that has not been previously set to render sitemaps. In that case, the second parameter is not explicitly used, as Yoast SEO will use its own matching `WPSEO_Sitemap_Provider` subclass to handle building the actual sitemap. The same is true if you wish to generate a (previously-excluded) taxonomy sitemap (where the first parameter is the taxonomy name).
+
+If a matching sitemap provider is not registered or cannot be found, the second parameter in the `register_sitemap` method must correspond to a callback function which must generate the entire sitemap XML.
+
 To remove a post type from your sitemaps, use the `wp_seo_sitemap_exclude_post_type` filter. The example below removes a post type registered as `recipe`.
 
 ```php

--- a/docs/xml-sitemaps.md
+++ b/docs/xml-sitemaps.md
@@ -41,6 +41,8 @@ add_filter( 'wpseo_sitemap_exclude_post_type', function ( $excluded, $post_type 
 
 You can similarly exclude specific posts, taxonomies or authors, using built in filters in Yoast SEO.
 
+## Adding Additional Sitemaps
+
 If you need to add additional sitemaps to the index, this can be done with the `wpseo_sitemap_index` filter. This filter allows you to add additional XML Sitemap URLs to the index.
 
 ```php

--- a/docs/xml-sitemaps.md
+++ b/docs/xml-sitemaps.md
@@ -149,4 +149,4 @@ add_filter( 'wpseo_sitemap_index', function ( string $sitemap_custom_items ) : s
 } )
 ```
 
-Additional examples and documentation can be found in the [Yoast SEO developer documentation](https://developer.yoast.com/features/xml-sitemaps/api).
+More examples and documentation can be found in the [Yoast SEO developer documentation](https://developer.yoast.com/features/xml-sitemaps/api).

--- a/docs/xml-sitemaps.md
+++ b/docs/xml-sitemaps.md
@@ -37,13 +37,101 @@ If a matching sitemap provider is not registered or cannot be found, the second 
 
 ## Excluding Content From XML Sitemaps
 
+### `wpseo_sitemap_exclude_post_type`
+
+Excludes a post type from your sitemaps. The example below removes a post type registered as `recipe`.
+
+**Parameters**
+
+**`$excluded`** _(bool)_ Whether the post type is excluded by default.
+
+**`$post_type`** _(string)_ The post type to exclude.
+
+**Example**
+
 ```php
-add_filter( 'wpseo_sitemap_exclude_post_type', function ( $excluded, $post_type ) {
+add_filter( 'wpseo_sitemap_exclude_post_type', function ( bool $excluded, string $post_type ) : bool {
 	return $post_type === 'recipe';
 }, 10, 2 );
 ```
 
-You can similarly exclude specific posts, taxonomies or authors, using built in filters in Yoast SEO.
+### `wpseo_sitemap_exclude_taxonomy`
+
+Excludes a taxonomy from your sitemaps. The example below removes a taxonomy that has been registered as `cuisine`.
+
+**Parameters**
+
+**`$excluded`** _(bool)_ Whether the taxonomy is excluded by default.
+
+**`$taxonomy`** _(string)_ The taxonomy to exclude.
+
+**Example**
+
+```php
+add_filter( 'wpseo_sitemap_exclude_taxonomy', function ( bool $excluded, string $taxonomy ) : bool {
+	return $taxonomy === 'cuisine';
+}, 10, 2 )
+```
+
+### `wpseo_exclude_from_sitemap_by_post_ids`
+
+Excludes specific posts from a sitemap by post IDs.
+
+**Example**
+
+```php
+add_filter( 'wpseo_exclude_from_sitemap_by_post_ids' function () : array {
+	return [ 1, 2, 3 ];
+} );
+```
+
+### `wpseo_exclude_from_sitemap_by_term_ids`
+
+Excludes specific taxonomy terms from a sitemap by term IDs.
+
+**Parameters**
+
+**`$terms`** _(array)_ Array of term IDs already excluded.
+
+**Example**
+
+```php
+add_filter( 'wpseo_exclude_from_sitemap_by_term_ids', function ( array $terms ) : array {
+	$term_ids_to_exclude = [ 3, 5, 9 ];
+
+	// Check if our excluded terms are already excluded.
+	foreach ( $term_ids_to_exclude as $i => $term_id ) {
+		if ( in_array( $term_id, $terms, true ) ) {
+			unset( $term_ids_to_exclude[ $i ] );
+		}
+	}
+
+	return $term_ids_to_exclude;
+} )
+```
+
+### `wpseo_sitemap_exclude_author`
+
+Exclude a specific author from the authors sitemap. The example below excludes an author with the slug `chris-reynolds` from the authors sitemap.
+
+**Parameters**
+
+**`$users`** _(array)_ Array of User objects to filter through.
+
+**Example**
+
+```php
+add_filter( 'wpseo_sitemap_exclude_author', function ( array $users ) : array {
+	$author_to_exclude = get_user_by( 'slug', 'chris-reynolds' );
+	return array_filter( $users, function ( $user ) use ( $author_to_exclude ) : bool {
+		if ( $user->ID === $author_to_exclude->ID ) {
+			return false;
+		}
+
+		return true;
+	} );
+} );
+```
 
 ## Adding Additional Sitemaps
 

--- a/docs/xml-sitemaps.md
+++ b/docs/xml-sitemaps.md
@@ -16,7 +16,7 @@ The XML Sitemaps in Altis are provided by our integration with [Yoast SEO](https
 
 It is necessary to [verify the site with Google Search Console](https://support.google.com/webmasters/answer/9008080?hl=en) before you can access information about your site's search results performance. It is recommended to use the HTML file upload solution by committing the file to your project's root directory, although it is possible to add the meta tag by filling in the [verification code on the Reading Settings page in the admin](admin://options-reading.php).
 
-## Adding or Removing Post Types
+## Adding Content to XML Sitemaps
 Sitemaps are provided for public content types like posts and pages out of the box. If you want to add support for additional custom post types in your sitemaps (for example, non-public post types or otherwise excluded post types), you can do so by using the built-in Yoast SEO functions and filters.
 
 To add a post type to the sitemaps, use the `register_sitemap` method of the `$wpseo_sitemaps` global like in the example below:

--- a/docs/xml-sitemaps.md
+++ b/docs/xml-sitemaps.md
@@ -17,7 +17,7 @@ The XML Sitemaps in Altis are provided by our integration with [Yoast SEO](https
 It is necessary to [verify the site with Google Search Console](https://support.google.com/webmasters/answer/9008080?hl=en) before you can access information about your site's search results performance. It is recommended to use the HTML file upload solution by committing the file to your project's root directory, although it is possible to add the meta tag by filling in the [verification code on the Reading Settings page in the admin](admin://options-reading.php).
 
 ## Adding or Removing Post Types
-Sitemaps are provided for public content types like posts and pages out of the box. If you want to add support for additional custom post types in your sitemaps, you can do so by using the built-in Yoast SEO filters.
+Sitemaps are provided for public content types like posts and pages out of the box. If you want to add support for additional custom post types in your sitemaps (for example, non-public post types or otherwise excluded post types), you can do so by using the built-in Yoast SEO functions and filters.
 
 To add a post type to the sitemaps, use the `register_sitemap` method of the `$wpseo_sitemaps` global like in the example below:
 

--- a/docs/xml-sitemaps.md
+++ b/docs/xml-sitemaps.md
@@ -138,7 +138,7 @@ add_filter( 'wpseo_sitemap_exclude_author', function ( array $users ) : array {
 If you need to add additional sitemaps to the index, this can be done with the `wpseo_sitemap_index` filter. This filter allows you to add additional XML Sitemap URLs to the index.
 
 ```php
-add_filter( 'wpseo_sitemap_index', function ( $sitemap_custom_items ) {
+add_filter( 'wpseo_sitemap_index', function ( string $sitemap_custom_items ) : string {
 	$sitemap_custom_items .= '
 <sitemap>
 	<loc>https://example.altis.cloud/external-sitemap-1.xml</loc>

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -23,13 +23,6 @@ function bootstrap( Module $module ) {
 		add_action( 'muplugins_loaded', __NAMESPACE__ . '\\load_redirects', 0 );
 	}
 
-	if ( $settings['xml-sitemaps'] ) {
-		add_filter( 'wp_sitemaps_enabled', '__return_true' );
-		add_filter( 'wp_sitemaps_add_provider', __NAMESPACE__ . '\\configure_sitemaps', 10, 2 );
-	} else {
-		add_filter( 'wp_sitemaps_enabled', '__return_false' );
-	}
-
 	if ( $settings['metadata'] ) {
 		add_action( 'muplugins_loaded', __NAMESPACE__ . '\\load_metadata', 0 );
 	}
@@ -172,35 +165,6 @@ function metadata_img_as_tachyon( array $meta, array $img_settings = [] ) : arra
 	}
 
 	return $meta;
-}
-
-/**
- * Filter sitemap providers.
- *
- * @param WP_Sitemaps_Provider $provider The sitemap provider class.
- * @param string $name The name of the provider.
- * @return WP_Sitemaps_Provider|false
- */
-function configure_sitemaps( $provider, string $name ) {
-	$settings = Altis\get_config()['modules']['seo']['xml-sitemaps'];
-
-	if ( ! is_array( $settings ) ) {
-		return $provider;
-	}
-
-	if ( $name === 'users' && ( $settings['users'] ?? true ) === false ) {
-		return false;
-	}
-
-	if ( $name === 'taxonomies' && ( $settings['taxonomies'] ?? true ) === false ) {
-		return false;
-	}
-
-	if ( $name === 'posts' && ( $settings['posts'] ?? true ) === false ) {
-		return false;
-	}
-
-	return $provider;
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -40,6 +40,9 @@ function bootstrap( Module $module ) {
 
 	// Read config/robots.txt file into robots.txt route handled by WP.
 	add_filter( 'robots_txt', __NAMESPACE__ . '\\robots_txt', 10 );
+
+	// Add sitemap to robots.txt.
+	add_filter( 'robots_txt', __NAMESPACE__ . '\\add_sitemap_index_to_robots', 11, 2 );
 }
 
 /**
@@ -189,6 +192,23 @@ function robots_txt( string $output ) : string {
 
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$output .= "\n" . file_get_contents( $legacy_file ) . "\n";
+	}
+
+	return $output;
+}
+
+/**
+ * Add the Yoast SEO sitemap index to the robots.txt file.
+ *
+ * @param string $output The original robots.txt content.
+ * @param bool $public Whether the site is public.
+ *
+ * @return string The filtered robots.txt content.
+ */
+function add_sitemap_index_to_robots( string $output, bool $public ) : string {
+	if ( $public ) {
+		$site_url = parse_url( site_url() );
+		$output .= esc_textarea( "Sitemap: {$site_url['scheme']}://{$site_url['host']}/sitemap_index.xml\n" );
 	}
 
 	return $output;

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -43,6 +43,9 @@ function bootstrap( Module $module ) {
 
 	// Add sitemap to robots.txt.
 	add_filter( 'robots_txt', __NAMESPACE__ . '\\add_sitemap_index_to_robots', 11, 2 );
+
+	// CSS overrides.
+	add_action( 'admin_enqueue_scripts', __NAMESPACE__ . '\\enqueue_yoast_css_overrides', 11 );
 }
 
 /**
@@ -207,8 +210,15 @@ function robots_txt( string $output ) : string {
  */
 function add_sitemap_index_to_robots( string $output, bool $public ) : string {
 	if ( $public ) {
-		$output .= sprintf( "Sitemap: %s/sitemap_index.xml\n", site_url() );
+		$output .= sprintf( "Sitemap: %s\n", site_url( '/sitemap_index.xml' ) );
 	}
 
 	return $output;
+}
+
+/**
+ * Enqueue CSS.
+ */
+function enqueue_yoast_css_overrides() {
+	wp_enqueue_style( 'altis-seo', plugin_dir_url( dirname( __FILE__ ) ) . 'assets/altis-seo.css', [], '2021-06-03' );
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -234,6 +234,6 @@ function enqueue_yoast_css_overrides() {
  * hook into their action to load in our style overrides.
  */
 function override_wizard_styles() {
-	wp_register_style( 'altis-seo', plugin_dir_url( dirname( __FILE__ ) ) . 'assets/global-styles.css', [], '2021-06-04-5' );
+	wp_register_style( 'altis-seo', plugin_dir_url( dirname( __FILE__ ) ) . 'assets/global-styles.css', [], '2021-06-04' );
 	wp_print_styles( 'altis-seo' );
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -74,7 +74,7 @@ function load_wpseo() {
 	if ( ! class_exists( 'WPSEO_Premium' ) ) {
 		if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
 			define( 'WPSEO_PREMIUM_FILE', $wpseo_file );
-			define( 'WPSEO_PREMIUM_VERSION', 8 );
+			define( 'WPSEO_PREMIUM_VERSION', Altis\get_version() );
 		}
 		require_once $wpseo_file;
 	}

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -208,7 +208,12 @@ function robots_txt( string $output ) : string {
 function add_sitemap_index_to_robots( string $output, bool $public ) : string {
 	if ( $public ) {
 		$site_url = parse_url( site_url() );
-		$output .= esc_textarea( "Sitemap: {$site_url['scheme']}://{$site_url['host']}/sitemap_index.xml\n" );
+		$output .= sprintf(
+			'Sitemap: %1$s://%2$s/sitemap_index.xml',
+			$site_url['scheme'],
+			$site_url['host']
+		);
+		$output .= "\n";
 	}
 
 	return $output;

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -224,7 +224,7 @@ function add_sitemap_index_to_robots( string $output, bool $public ) : string {
  * Enqueue CSS.
  */
 function enqueue_yoast_css_overrides() {
-	wp_enqueue_style( 'altis-seo', plugin_dir_url( dirname( __FILE__ ) ) . 'assets/altis-seo.css', [], '2021-06-03' );
+	wp_enqueue_style( 'altis-seo', plugin_dir_url( dirname( __FILE__ ) ) . 'assets/altis-seo.css', [], '2021-06-04-5' );
 }
 
 /**

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -234,6 +234,6 @@ function enqueue_yoast_css_overrides() {
  * hook into their action to load in our style overrides.
  */
 function override_wizard_styles() {
-	wp_register_style( 'altis-seo', plugin_dir_url( dirname( __FILE__ ) ) . 'assets/global-styles.css', [], '2021-06-04' );
+	wp_register_style( 'altis-seo', plugin_dir_url( dirname( __FILE__ ) ) . 'assets/global-styles.css', [], '2021-06-04-5' );
 	wp_print_styles( 'altis-seo' );
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -76,8 +76,10 @@ function load_wpseo() {
 
 	// Define a fake WP SEO Premium File value if we don't have WP SEO Premium installed. This hides some of the upsell UI.
 	if ( ! class_exists( 'WPSEO_Premium' ) ) {
-		define( 'WPSEO_PREMIUM_FILE', $wpseo_file );
-		define( 'WPSEO_PREMIUM_VERSION', 8 );
+		if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+			define( 'WPSEO_PREMIUM_FILE', $wpseo_file );
+			define( 'WPSEO_PREMIUM_VERSION', 8 );
+		}
 		require_once $wpseo_file;
 	}
 }

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -207,13 +207,7 @@ function robots_txt( string $output ) : string {
  */
 function add_sitemap_index_to_robots( string $output, bool $public ) : string {
 	if ( $public ) {
-		$site_url = parse_url( site_url() );
-		$output .= sprintf(
-			'Sitemap: %1$s://%2$s/sitemap_index.xml',
-			$site_url['scheme'],
-			$site_url['host']
-		);
-		$output .= "\n";
+		$output .= sprintf( "Sitemap: %s/sitemap_index.xml\n", site_url() );
 	}
 
 	return $output;

--- a/load.php
+++ b/load.php
@@ -31,7 +31,6 @@ add_action( 'altis.modules.init', function () {
 				'tumblr' => '',
 			],
 		],
-		'xml-sitemaps' => true,
 		'site-verification' => true,
 	];
 	Altis\register_module( 'seo', __DIR__, 'SEO', $default_settings, __NAMESPACE__ . '\\bootstrap' );


### PR DESCRIPTION
Removes internal XML sitemaps handling and lets Yoast take care of it. 
Updates documentation and adds link to sitemap in robots.txt.