### PR TITLE
Fix WP SEO option filter

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -57,7 +57,7 @@ function bootstrap( Module $module ) {
 	add_filter( 'wpseo_helpscout_show_beacon', '__return_false' );
 
 	// Hide the HUGE SEO ISSUE warning and disable admin bar menu.
-	add_filter( 'pre_option_wpseo', __NAMESPACE__ . '\\override_yoast_seo_options', 20 );
+	add_filter( 'option_wpseo', __NAMESPACE__ . '\\override_yoast_seo_options', 20 );
 
 	// Read config/robots.txt file into robots.txt route handled by WP.
 	add_filter( 'robots_txt', __NAMESPACE__ . '\\robots_txt', 10 );


### PR DESCRIPTION
Fixes #83
Fixes #88

This filter should have been on `option_wpseo` as `pre_option_wpseo` short circuits the stored value.