### PR TITLE
Enable Yoast db indexing on all envs

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -79,6 +79,9 @@ function bootstrap( Module $module ) {
 	add_action( 'wpseo_configuration_wizard_head', __NAMESPACE__ . '\\override_wizard_styles' );
 	add_action( 'admin_head', __NAMESPACE__ . '\\hide_yoast_premium_social_previews' );
 
+	// Intend to save indexables.
+	add_filter( 'wpseo_should_save_indexable', '__return_true' );
+
 	// Migrations.
 	add_action( 'altis.migrate', __NAMESPACE__ . '\\do_migrations' );
 }


### PR DESCRIPTION
By default Yoast SEO bypasses saving indexables to the db on any non production environments. This can be a bit confusing and also surfaces some bugs when running the indexing command.