### PR TITLE
Fix Yoast Premium path constant

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -129,7 +129,7 @@ function load_wpseo() {
 	}
 
 	if ( ! defined( 'WPSEO_PREMIUM_PATH' ) ) {
-		define( 'WPSEO_PREMIUM_PATH', Altis\ROOT_DIR . '/vendor/yoast/wordpress-seo-premium' );
+		define( 'WPSEO_PREMIUM_PATH', Altis\ROOT_DIR . '/vendor/yoast/wordpress-seo-premium/' );
 	}
 
 	if ( ! defined( 'WPSEO_PREMIUM_BASENAME' ) ) {


### PR DESCRIPTION
The path should have a trailing slash per https://github.com/wordpress-premium/wpseo-premium/blob/master/wp-seo-premium.php#L48