### PR TITLE
Update Redirects to 0.7.0 - breaking changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.1",
-        "humanmade/hm-redirects": "~0.6.1",
+        "humanmade/hm-redirects": "~0.7.0",
         "yoast/wordpress-seo": "^17.9"
     },
     "autoload": {


### PR DESCRIPTION
This update fixes #173, a bug where query string parameters were not preserved when redirecting. Further to the problem the query string was also used to match the redirect in the database which meant redirects were not happening when for example UTM parameters were present.