### PR TITLE
Support --quiet flag for migrate command suggestion

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -530,7 +530,7 @@ function hide_yoast_premium_social_previews() {
  * @return void
  */
 function suggest_migrations() : void {
-	WP_CLI::line( WP_CLI::colorize( '%yTo migrate SEO data for Altis v7 or earlier to Yoast SEO run `wp altis migrate-seo`%n' ) );
+	WP_CLI::log( WP_CLI::colorize( '%yTo migrate SEO data for Altis v7 or earlier to Yoast SEO run `wp altis migrate-seo`%n' ) );
 }
 
 /**


### PR DESCRIPTION
Using `WP_CLI::line()` bypasses the `--quiet` setting for WP CLI. We should respect it here.