### PR TITLE
Fix the added elements to the sitewide active plugins for Yoast plugins.

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -201,7 +201,7 @@ function active_yoast_plugins( $active_plugins ) {
 	foreach ( YOAST_PLUGINS as $plugin_file ) {
 		$plugin_path = Altis\ROOT_DIR . '/vendor/yoast/' . $plugin_file;
 		if ( is_readable( $plugin_path ) ) {
-			$active_plugins[] = $plugin_file;
+			$active_plugins[ $plugin_file ] = time();
 		}
 	}
 


### PR DESCRIPTION
The original array has the plugin file as key and the date it is activated as value.