### PR TITLE
Display the social tab in Yoast.

### DIFF
--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -511,16 +511,6 @@ function hide_yoast_premium_social_previews() {
 		display: none;
 	}';
 
-	/**
-	 * Hide the Social tab in the Yoast Metabox.
-	 *
-	 * The Google preview is in the basic SEO tab and social previews
-	 * are only available for Yoast SEO Premium.
-	 */
-	$styles .= '.wpseo-metabox-menu .yoast-aria-tabs li:last-of-type {
-		display:none;
-	}';
-
 	echo "<style>$styles</style>"; // phpcs:ignore HM.Security.EscapeOutput.OutputNotEscaped
 }
 


### PR DESCRIPTION
Related Issue - https://github.com/humanmade/product-dev/issues/1248

This PR ensures the Yoast Social tab that was previously hidden is now visible.

#### Before 
<img width="751" alt="Screenshot 2022-10-24 at 10 09 01" src="https://user-images.githubusercontent.com/16571365/197478682-081d5fe0-e0b6-4960-977e-83f4bd46e504.png">


#### After
<img width="745" alt="Screenshot 2022-10-24 at 10 09 25" src="https://user-images.githubusercontent.com/16571365/197478723-b1d673b9-498a-4513-8780-e3b537a6a3de.png">

