### PR TITLE
Issue 332 revert yoast to less than 17.14

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=7.1",
         "humanmade/hm-redirects": "~0.7.2",
-        "yoast/wordpress-seo": "^20.4"
+        "yoast/wordpress-seo": "<17.14"
     },
     "autoload": {
         "files": [


### PR DESCRIPTION
Addresses issue https://github.com/humanmade/altis-seo/issues/332
This for V12-branch only. Not for master.