### PR TITLE
Reformat docs files after linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 # Import Travis configuration from dev-tools repo
 version: ~> 1.0
 import:
-  - source: humanmade/altis-dev-tools:travis/module.yml@f1fd9a5
+  - source: humanmade/altis-dev-tools:travis/module.yml@0bfa112a
     mode: deep_merge_append
 
 # Add your custom config below, which will merge with the default module config from the section above.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # SEO
 
-![](./assets/banner-seo.png)
+![SEO banner](./assets/banner-seo.png)
 
 ## Configuration
 
@@ -8,16 +8,16 @@ The following JSON is the default configuration for the module and can be overri
 
 ```json
 {
-	"extra": {
-		"altis": {
-			"modules": {
-				"seo": {
-					"enabled": true
-					},
-					"redirects": true
-				}
-			}
-		}
-	}
+    "extra": {
+        "altis": {
+            "modules": {
+                "seo": {
+                    "enabled": true
+                    },
+                    "redirects": true
+                }
+            }
+        }
+    }
 }
 ```

--- a/docs/redirects.md
+++ b/docs/redirects.md
@@ -2,35 +2,47 @@
 
 Redirects have many uses, not just for SEO and marketing but also for migrating sites or moving content around.
 
-The redirects component is architected for performance and scale by using indexed data in the CMS database. They can be exported and imported using standard WXR format files.
+The redirects component is built for performance and scale by using indexed data in the CMS database. They can be exported and
+imported using standard WXR format files.
 
 ## Whitelisting redirect hosts
 
-For security purposes redirects only work within the current host name by default. To redirect to other domains external to the current host use the following filter:
+For security purposes redirects only work within the current host name by default. To redirect to other domains external to the
+current host use the following filter:
 
 ```php
 add_filter( 'allowed_redirect_hosts', function ( array $hosts ) : array {
-	$hosts[] = 'example.com';
-	return $hosts;
+    $hosts[] = 'example.com';
+    return $hosts;
 }, 10 );
 ```
 
 ## CLI commands
 
-**`wp hm-redirects find-domains`**
+```shell
+wp hm-redirects find-domains
+```
 
-Extracts a list of unique target domains from your existing redirects. This is useful for populating the `allowed_redirect_hosts` filter.
+Extracts a list of unique target domains from your existing redirects. This is useful for populating the `allowed_redirect_hosts`
+filter.
 
-**`wp hm-redirects insert-redirect <from-url> <to-url>`**
+```shell
+wp hm-redirects insert-redirect <from-url> <to-url>
+```
 
 Adds a redirect rule.
 
-**`wp hm-redirects import-from-csv --csv=<path-to-csv> [--verbose]`**
+```shell
+wp hm-redirects import-from-csv --csv=<path-to-csv> [--verbose]
+```
 
 Imports redirects from a CSV file. The file must have 2 columns, column 1 being the "from" URL and column 2 being to the "to" URL.
-
 The "to" URL can be a full URL, a relative path or an existing post ID.
 
-**`wp hm-redirects import-from-meta --meta_key=<name-of-meta-key> [--start=<start-offset>] [--end=<end-offset>] [--dry_run] [--verbose]`**
+```shell
+wp hm-redirects import-from-meta --meta_key=<name-of-meta-key> [--start=<start-offset>] [--end=<end-offset>] [--dry_run]
+ [--verbose]
+```
 
-If you have existing redirect URLs or paths stored as meta data on the posts they should redirect to you can use this command to migrate to the more performant structure.
+If you have existing redirect URLs or paths stored as metadata on posts, you can use this command to migrate to the more efficient
+structure.


### PR DESCRIPTION
This changes all the docs files to be formatted correctly after linting. The main changes are line length, spaces instead of tabs, and addition of alt text for images.

Resolves https://github.com/humanmade/altis-seo/issues/290