### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - main
+      - 'v*-branch'
+  pull_request:
+    branches:
+      - master
+      - main
+      - 'v*-branch'
+
+jobs:
+  ci:
+    uses: humanmade/altis-dev-tools/.github/workflows/module-ci.yml@master
+    with:
+      altis-package: altis/seo
+    secrets:
+      DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
## Summary

Replaces `.travis.yml` with a thin caller for the reusable Module CI workflow at `humanmade/altis-dev-tools/.github/workflows/module-ci.yml`. The Travis file is left in place for the side-by-side migration window — remove in a follow-up once GHA is consistently green.

## Dependency

Requires the companion PR in `humanmade/altis-dev-tools` to merge first (adds the reusable workflow). Until that lands, this workflow will fail to load.

- Addresses: https://github.com/humanmade/product-dev/issues/1539

## Test plan

- [ ] CI runs green once the dev-tools PR is merged
- [ ] `DOCKER_USERNAME` / `DOCKER_PASSWORD` repo secrets exist
- [ ] Codeception output uploads as artifact on a forced failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)