### PR TITLE
Restrict non-master Dependabot updates to patch-level

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,11 @@ updates:
   target-branch: v26-branch
   commit-message:
     prefix: "[v26-branch]"
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-major"
+        - "version-update:semver-minor"
 - package-ecosystem: composer
   directory: "/"
   schedule:
@@ -32,6 +37,11 @@ updates:
   target-branch: v25-branch
   commit-message:
     prefix: "[v25-branch]"
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-major"
+        - "version-update:semver-minor"
 - package-ecosystem: composer
   directory: "/"
   schedule:
@@ -43,6 +53,11 @@ updates:
   target-branch: v24-branch
   commit-message:
     prefix: "[v24-branch]"
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-major"
+        - "version-update:semver-minor"
 - package-ecosystem: composer
   directory: "/"
   schedule:
@@ -54,3 +69,8 @@ updates:
   target-branch: v23-branch
   commit-message:
     prefix: "[v23-branch]"
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - "version-update:semver-major"
+        - "version-update:semver-minor"


### PR DESCRIPTION
## Summary
- Adds a wildcard `ignore` rule for `version-update:semver-major` and `version-update:semver-minor` to the v23/v24/v25/v26 Dependabot entries.
- Non-master branches will now only receive patch-release PRs, reducing churn on maintenance branches that shouldn't take feature bumps.
- Master continues to receive everything.

## Test plan
- [ ] After merge, confirm the next weekly Dependabot run on a non-master branch only opens patch-level PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)